### PR TITLE
fixed connectionstring to be compatible with EF Core 7.0

### DIFF
--- a/PedaloWebApp/appsettings.json
+++ b/PedaloWebApp/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=.\\sqlexpress;Initial Catalog=RentAPedalo;Integrated Security=SSPI"
+    "DefaultConnection": "Server=.\\sqlexpress;Initial Catalog=RentAPedalo;Integrated Security=SSPI;Encrypt=False"
   }
 }

--- a/PedaloWebApp/appsettings.json
+++ b/PedaloWebApp/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=.\\sqlexpress;Initial Catalog=RentAPedalo;Integrated Security=SSPI;Encrypt=False"
+    "DefaultConnection": "Server=.\\sqlexpress;Initial Catalog=RentAPedalo;Integrated Security=SSPI;TrustServerCertificate=True"
   }
 }


### PR DESCRIPTION
 (more information about the breaking change: https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-7.0/breaking-changes#encrypt-defaults-to-true-for-sql-server-connections)