### PR TITLE
Re-enable suppression checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: neolution-ch/action-check-suppressions@v1
         with:
-          continueOnError: true
+          continueOnError: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-dotnet@v4


### PR DESCRIPTION
Re-enables the suppression check action in the CI workflow.
This reverts a previous change that disabled the check for the migration PR #7.